### PR TITLE
Avoid removing default list on -all buttons clicks

### DIFF
--- a/js/monoTab.js
+++ b/js/monoTab.js
@@ -308,7 +308,11 @@ function deleteMultipleLinks(arrayOfLinks, listId) {
     var currentTabs = (tabsArray.monotabdata === null) ? {} : JSON.parse(tabsArray.monotabdata)
     var listInQuestion = currentTabs[listId]
 
-    delete currentTabs[listId]
+    if (listId === 'defaultList') {
+      currentTabs[listId] = []
+    } else {
+      delete currentTabs[listId]
+    }
 
     chrome.storage.sync.set({'monotabdata': JSON.stringify(currentTabs)})
   })


### PR DESCRIPTION
#### Fixes
* Avoid removing default list on expand-all, and delete-all buttons clicks on that list

#### New Changes
* None

#### Notes
Please PR against the staging branch

